### PR TITLE
trap loadstring errors

### DIFF
--- a/template.lua
+++ b/template.lua
@@ -52,7 +52,11 @@ function template.parse(data, minify)
 end
 
 function template.compile(...)
-  return loadstring(template.parse(...))()
+  local f, err = loadstring(template.parse(...))
+  if err then
+    error(err)
+  end
+  return f()
 end
 
 return template


### PR DESCRIPTION
if there's an error in the template, any problem with it is swallowed by ignoring the return value of loadstring. check it and raise it if not nil.